### PR TITLE
feat: cross-platform start script and PORT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,75 @@ El archivo `game.js` incluye hooks preparados para networking:
 
 ## 📦 Instalación y Ejecución
 
-1. Abrir `index.html` en un navegador moderno.
-2. Recomendado usar un servidor local para evitar problemas con recursos estáticos:
+### Ejecutar en el navegador (sin usar `npm run start`) ✅
+
+Puedes probar el juego en tu navegador local sin usar el script `npm run start`:
+
+- **Opción A — Abrir directamente (simple):** Abrir `index.html` con el navegador (ruta `file://`). *Nota:* algunos navegadores pueden restringir módulos o peticiones por seguridad; si ves errores en la consola usa la Opción B.
+
+- **Opción B — Servidor estático rápido (recomendado):** Si tienes Python instalado, en la raíz del proyecto ejecuta:
+  ```bash
+  python3 -m http.server 8000
+  ```
+  luego abre `http://localhost:8000` en tu navegador.
+
+- **Opción C — Servir con Node.js sin usar `npm run start`:** Si prefieres usar Node.js sin ejecutar un script `npm`, puedes usar `npx` para ejecutar un servidor temporal:
+  ```bash
+  npx serve . -l 8000
+  ```
+  (Esto requiere Node.js instalado, pero no necesita crear o ejecutar un script en `package.json`.)
+
+### Modo multijugador con Node.js (Socket.IO) 🔧
+
+El proyecto incluye `server.js` para el modo multijugador usando Express + Socket.IO.
+
+1. Asegúrate de tener Node.js instalado (v16+).
+2. Instala dependencias (solo la primera vez):
    ```bash
-   python3 -m http.server 8000
+   npm install
    ```
+   Esto instalará `express` y `socket.io` como aparecen en `package.json`.
+3. Inicia el servidor con Node (sin `npm run start`):
+   ```bash
+   node server.js
+   ```
+   Por defecto escucha en `http://localhost:3000`, pero también puede leer la variable de entorno `PORT`. Por ejemplo:
+   ```bash
+   PORT=4000 node server.js
+   ```
+   (En PowerShell de Windows usa: `$env:PORT=4000; node server.js`.)
+
+   También hay un script npm conveniente incluido en `package.json`:
+   ```bash
+   npm run start:port
+   ```
+   **Recomendado (portátil):** Este script arranca el servidor en el puerto `4000` por defecto si `PORT` no está definido, usando un pequeño wrapper en Node que funciona en todas las plataformas.
+
+   - Para usar otro puerto, define la variable `PORT` antes de ejecutar el script:
+     - Linux/macOS:
+       ```bash
+       PORT=5000 npm run start:port
+       ```
+     - PowerShell (Windows):
+       ```powershell
+       $env:PORT=5000; npm run start:port
+       ```
+
+   También puedes ejecutar directamente sin npm:
+   ```bash
+   PORT=5000 node server.js
+   ```
+
+   Nota: `cross-env` se mantuvo en `devDependencies` como opción alternativa si la prefieres.
+
+4. Abre `http://localhost:3000` (o `http://localhost:<PORT>` si usaste otra configuración) en uno o varios navegadores/dispositivos para probar el multijugador. El servidor ya permite conexiones desde cualquier origen (CORS: "*") para facilitar pruebas locales.
+
+> Nota: Si necesitas cambiar el puerto en pruebas locales o producción, establece la variable de entorno `PORT` antes de iniciar el servidor (por ejemplo `PORT=4000 node server.js`). Si prefieres, también puedes editar `server.js`.
+
+### Consejos rápidos 📝
+
+- Para pruebas en la red local, usa la IP de la máquina (ej. `http://192.168.1.5:3000`).
+- Para mantener el servidor en ejecución en segundo plano en Linux, considera `nohup node server.js &` o usar `pm2`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "start:port": "node -e \"process.env.PORT = process.env.PORT || 4000; require('./server');\""
   },
   "keywords": [],
   "author": "",
@@ -13,5 +14,8 @@
   "dependencies": {
     "express": "^5.2.1",
     "socket.io": "^4.8.3"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -20,5 +20,7 @@ io.on('connection', (socket) => {
   });
 });
 
-server.listen(3000);
-console.log('🎮 Neon Hunter server en puerto 3000');
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`🎮 Neon Hunter server en puerto ${PORT}`);
+});


### PR DESCRIPTION
Makes the server read PORT from env, adds a portable npm script (start:port) and documents usage in README.